### PR TITLE
add required -std flag to g++

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Clover is UCI compatible, but doesn't have a GUI, so, in order to play with it, 
 
 If you want to compile locally, I recommend you to use:
 
-```g++ *.cpp *.c -march=native -Wall -O3 -o output.exe```
+```g++ *.cpp *.c -march=native -Wall -O3 -o output.exe -std=c++11```
 
 without ```-flto```, because it crashes for some strange reason.
 


### PR DESCRIPTION
also, without using the windows.h header file, it works perfectly..