### PR TITLE
scale score down if pawns are on only 1 flank, tune scale terms

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -62,6 +62,9 @@ const uint64_t LONG_DIAGONALS =  9314046665258451585ULL;
 const std::string START_POS_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
 bool TUNE = false; /// false by default, automatically set to true when tuning
+const int TUNE_SCALE = 1;
+const int TUNE_TERMS = 2;
+const int TUNE_FLAG = TUNE_SCALE;
 
 int cod[256];
 uint64_t hashKey[13][64], castleKey[2][2], enPasKey[64];

--- a/defs.h
+++ b/defs.h
@@ -73,7 +73,7 @@ uint64_t fileUpMask[64], neighFileUpMask[64];
 uint64_t fileDownMask[64], neighFileDownMask[64];
 uint64_t neighFilesMask[64];
 uint64_t between[64][64], Line[64][64];
-uint64_t flankMask[8];
+uint64_t flankMask[2];
 int mirrorSq[2][64];
 int distance[64][64];
 
@@ -343,14 +343,8 @@ inline void init_defs() {
     }
   }
 
-  /// flank mask if we are on a file
-  uint64_t queenSide = fileMask[0] | fileMask[1] | fileMask[2] | fileMask[3], kingSide = fileMask[4] | fileMask[5] | fileMask[6] | fileMask[7];
-
-  flankMask[0] = queenSide ^ fileMask[3];
-  flankMask[1] = flankMask[2] = queenSide;
-  flankMask[3] = flankMask[4] = fileMask[3] | fileMask[4] | fileMask[5] | fileMask[6];
-  flankMask[5] = flankMask[6] = kingSide;
-  flankMask[7] = kingSide ^ fileMask[7];
+  flankMask[0] = fileMask[0] | fileMask[1] | fileMask[2] | fileMask[3];
+  flankMask[1] = fileMask[4] | fileMask[5] | fileMask[6] | fileMask[7];
 
   /// generate all squares that are above and below a square
 

--- a/evaluate.h
+++ b/evaluate.h
@@ -885,6 +885,8 @@ int scaleFactor(Board &board, int eg) {
   bool oppositeBishops = 0;
   int color = (eg > 0 ? WHITE : BLACK);
   int scale = 100;
+    uint64_t allPawns = board.bb[WP] | board.bb[BP];
+
   if(count(board.bb[WB]) == 1 && count(board.bb[BB]) == 1) {
     int sq1 = Sq(board.bb[WB]), sq2 = Sq(board.bb[BB]);
     if(oppositeColor(sq1, sq2))
@@ -895,11 +897,10 @@ int scaleFactor(Board &board, int eg) {
 
   if(oppositeBishops)
     scale = 50 + 10 * (count(board.pieces[color] ^ board.bb[getType(PAWN, color)]) - 2); /// without the king and the bishop
-  /* // doesn't work (loses elo)
-  else {
-    /// thanks to https://hxim.github.io/Stockfish-Evaluation-Guide/ for this idea
-    scale = 80 +  5 * count(board.bb[getType(PAWN, color)]);
-  }*/
+
+  /// positions with pawns on only 1 flank tend to be drawish
+
+  scale -= 10 * ((allPawns & flankMask[0]) && (allPawns & flankMask[1]));
 
   scale = std::min(scale, 100);
 

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 CC  = g++
 SRC = *.cpp tbprobe.c
-EXE = Clover.2.4-dev29
+EXE = Clover.2.4-dev30
 WFLAGS = -Wall
 RFLAGS = $(WFLAGS) -std=c++17 -O3 -static -static-libgcc -static-libstdc++
 LIBS   = -pthread

--- a/thread.h
+++ b/thread.h
@@ -15,6 +15,7 @@ int SNMPCoef1 = 85;
 int SNMPCoef2 = 20;
 int seeCoefQuiet = 80;
 int seeCoefNoisy = 18;
+int fpCoef = 90; /// 51
 
 const int TERMINATED_BY_USER = 1;
 const int TERMINATED_BY_TIME = 2;

--- a/uci.h
+++ b/uci.h
@@ -33,7 +33,7 @@
 /// is this working?
 /// i guess so?
 
-const std::string VERSION = "2.4-dev29"; /// 2.0 was "FM"
+const std::string VERSION = "2.4-dev30"; /// 2.0 was "FM"
 
 char line[INPUTBUFFER];
 
@@ -265,7 +265,7 @@ void UCI :: Uci_Loop() {
               //cout << "Set TB path to " << path << "\n";
             }
 
-            /// search params
+            /// search params, used by ctt
 
             if(name == "RazorCoef") {
               iss >> value;
@@ -302,6 +302,13 @@ void UCI :: Uci_Loop() {
 
               iss >> val;
               seeCoefNoisy = val;
+            } else if(name == "fpCoef") {
+              iss >> value;
+
+              int val;
+
+              iss >> val;
+              fpCoef = val;
             }
 
           } else if(cmd == "tune") {
@@ -393,6 +400,8 @@ void UCI :: Perft(int depth) {
   std::cout << "time : " << t << std::endl;
   std::cout << "nps  : " << nps << std::endl;
 }
+
+/// positions used for benching
 
 std::string benchPos[] = {
   "r3k2r/2pb1ppp/2pp1q2/p7/1nP1B3/1P2P3/P2N1PPP/R2QK2R w KQkq a6 0 14   ",


### PR DESCRIPTION
Very ugly tuner code tho.
```
ELO   | 11.09 +- 6.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 4576 W: 1080 L: 934 D: 2562
```