### PR TITLE
Don't update tt with best move if we don't beat alpha

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -1,6 +1,6 @@
 CC  = g++
 SRC = *.cpp tbprobe.c
-EXE = Clover.5.0.10
+EXE = Clover.5.0.11
 EVALFILE = weights-5buckets-epoch310.nnue
 
 ifeq ($(OS), Windows_NT)

--- a/src/search.h
+++ b/src/search.h
@@ -632,7 +632,7 @@ int Search::search(int alpha, int beta, int depth, bool cutNode, StackEntry* sta
     /// update tt only if we aren't in a singular search
     if (!excluded) {
         bound = (best >= beta ? LOWER : (best > alphaOrig ? EXACT : UPPER));
-        TT->save(key, best, depth, ply, bound, bestMove, staticEval);
+        TT->save(key, best, depth, ply, bound, (bound == UPPER ? NULLMOVE : bestMove), staticEval);
     }
 
     return best;

--- a/src/tt.h
+++ b/src/tt.h
@@ -157,8 +157,11 @@ inline void tt::HashTable::save(uint64_t hash, int score, int depth, int ply, in
     temp.hash = hash;
 
     if (bucket->hash == hash) {
-        if (bound == EXACT || depth >= bucket->depth() - 3)
+        if (bound == EXACT || depth >= bucket->depth() - 3) {
+            if (move == NULLMOVE)
+                temp.move = bucket->move;
             *bucket = temp;
+        }
         return;
     }
 
@@ -167,6 +170,8 @@ inline void tt::HashTable::save(uint64_t hash, int score, int depth, int ply, in
     for (int i = 1; i < BUCKET; i++) {
         if ((bucket + i)->hash == hash) {
             if (bound == EXACT || depth >= bucket->depth() - 3) {
+                if (move == NULLMOVE)
+                    temp.move = (bucket + i)->move;
                 *(bucket + i) = temp;
             }
             return;
@@ -176,6 +181,8 @@ inline void tt::HashTable::save(uint64_t hash, int score, int depth, int ply, in
         }
     }
 
+    if (move == NULLMOVE)
+        temp.move = replace->move;
     *replace = temp;
 }
 


### PR DESCRIPTION
The best move in fail low nodes is useless, as we failed to beat alpha and we only have an upper bound.

Bench: 3163279