### PR TITLE
Rework logic of TT aging

### DIFF
--- a/src/generate.h
+++ b/src/generate.h
@@ -69,7 +69,7 @@ void generateFens(SearchThread &thread_data, std::atomic<uint64_t>& sumFens, std
         thread_data.clear_history();
         thread_data.clear_stack();
 
-        thread_data.TT->initTable(4 * MB);
+        thread_data.TT->init(4 * MB);
         std::uniform_int_distribution <int> rnd_ply(0, 100000);
 
         int additionalPly = rnd_ply(gn) % 2;

--- a/src/makefile
+++ b/src/makefile
@@ -1,7 +1,7 @@
 SRCXX = $(wildcard *.cpp)
 SRC = 3rdparty/Fathom/src/tbprobe.c
 OBJ = $(SRCXX:.cpp=.o) $(SRC:.c=.o)
-EXE = Clover.8.1.6
+EXE = Clover.8.1.7
 EVALFILE = clover-7buckets-mse-0.95-1280-cosine-600.bin
 
 ifeq ($(CXX),)

--- a/src/search.h
+++ b/src/search.h
@@ -688,7 +688,7 @@ void SearchThread::print_iteration_info(bool san_mode, int multipv, int score, i
         if (score >= beta) std::cout << " lowerbound";
         else if (score <= alpha) std::cout << " upperbound";
 
-        std::cout << " depth " << depth << " sel_depth " << sel_depth << " nodes " << total_nodes;
+        std::cout << " depth " << depth << " seldepth " << sel_depth << " nodes " << total_nodes;
         if (t)
             std::cout << " nps " << total_nodes * 1000 / t;
         std::cout << " time " << t << " ";

--- a/src/tt.h
+++ b/src/tt.h
@@ -163,12 +163,12 @@ Entry* HashTable::probe(const uint64_t hash, bool &ttHit) {
 
     for (int i = 0; i < BUCKET_COUNT; i++) {
         if (bucket[i].hash == hash16) {
-            ttHit = 1;
+            ttHit = true;
             return bucket + i;
         }
     }
 
-    ttHit = 0;
+    ttHit = false;
     int idx = 0;
     for (int i = 1; i < BUCKET_COUNT; i++) {
         if (bucket[i].depth() - 2 * bucket[i].generation_diff(generation) < 

--- a/src/tt.h
+++ b/src/tt.h
@@ -171,8 +171,8 @@ Entry* HashTable::probe(const uint64_t hash, bool &ttHit) {
     ttHit = 0;
     int idx = 0;
     for (int i = 1; i < BUCKET_COUNT; i++) {
-        if (bucket[i].depth() - bucket[i].generation_diff(generation) < 
-            bucket[idx].depth() - bucket[idx].generation_diff(generation)) idx = i;
+        if (bucket[i].depth() - 2 * bucket[i].generation_diff(generation) < 
+            bucket[idx].depth() - 2 * bucket[idx].generation_diff(generation)) idx = i;
     }
 
     return bucket + idx;

--- a/src/uci.h
+++ b/src/uci.h
@@ -185,7 +185,7 @@ void UCI::uci_loop() {
             if (name == "Hash") {
                 iss >> value >> ttSize;
 #ifndef GENERATE
-                TT->initTable(ttSize * MB, thread_pool.get_num_threads());
+                TT->init(ttSize * MB, thread_pool.get_num_threads());
 #endif
             }
             else if (name == "Threads") {
@@ -286,8 +286,7 @@ void UCI::uci() {
 void UCI::ucinewgame(uint64_t ttSize) {
     thread_pool.clear_history();
 #ifndef GENERATE
-    TT->reset_age();
-    TT->initTable(ttSize * MB, thread_pool.get_num_threads());
+    TT->init(ttSize * MB, thread_pool.get_num_threads());
 #endif
 }
 


### PR DESCRIPTION
Don't refresh the entry generation each time when probed. Also, don't refresh the whole table when generation goes above 63.